### PR TITLE
Made `miniscore()` multi-player capable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,6 +62,8 @@
         "unordered_map": "cpp",
         "utility": "cpp",
         "__tree": "cpp",
-        "set": "cpp"
+        "set": "cpp",
+        "__bits": "cpp",
+        "deque": "cpp"
     }
 }

--- a/project/project_03-upgrade_minimax.md
+++ b/project/project_03-upgrade_minimax.md
@@ -57,4 +57,4 @@
      + Build a new test inside `miniscore_test.cc` for that multiplayer feature.
        - Use a 6x6 board, 3 players, and a winning length of 3.
        - Adapt Developer Mode inside `miniscore()` to aptly display all player's scores.
-       -  Check with Developer Mode if the new feature performs as expected.
+       - Check with Developer Mode if the new feature performs as expected.

--- a/project/to_do.md
+++ b/project/to_do.md
@@ -1,3 +1,8 @@
 # Current to do items
 
+* Current step in project: End of objective 1. Before test can be written, some compile time problems have to be fixed.
+  +  In `miniscore.cc`, a solution has to be found for getting the max value of a deque.
+  +  In `miniscore.cc`, a solution has to be found for letting the algorithm know the size of the group.
+
+
 * Developer Mode is now spread out over 2 algorithms. It should be more centralized into functions or something like that.

--- a/project/to_do.md
+++ b/project/to_do.md
@@ -1,7 +1,6 @@
 # Current to do items
 
 * Current step in project: End of objective 1. Before test can be written, some compile time problems have to be fixed.
-  +  In `miniscore.cc`, a solution has to be found for getting the max value of a deque.
   +  In `miniscore.cc`, a solution has to be found for letting the algorithm know the size of the group.
 
 

--- a/project/to_do.md
+++ b/project/to_do.md
@@ -1,7 +1,16 @@
 # Current to do items
 
-* Current step in project: End of objective 1. Before test can be written, some compile time problems have to be fixed.
-  +  In `miniscore.cc`, a solution has to be found for letting the algorithm know the size of the group.
-
+* Current step in project: End of objective 1. 
+    + Player test has to be modified for the new Player.group object
+    + miniscore test has to be added to test behaviour with more than two players
+      - Ideas:
+        - begin with small tests just to check if there are no obvious bugs
+        - Then the planned 6x6 multi-player test
+        - Include option to choose between (1?,) 2, 3 and 4 players.
+* Perform tests and debug code. (also improve Developer Mode)
+  * what small tests can be done whithout entire game?
+  * What does Developer Mode need for multiplayer?
+  * are hints/guidelines on what to look for in Developer Mode a good idea?
+  
 
 * Developer Mode is now spread out over 2 algorithms. It should be more centralized into functions or something like that.

--- a/project/to_do.md
+++ b/project/to_do.md
@@ -1,3 +1,3 @@
 # Current to do items
 
-- All current items done.
+* Developer Mode is now spread out over 2 algorithms. It should be more centralized into functions or something like that.

--- a/structures/algorithms/miniscore.cc
+++ b/structures/algorithms/miniscore.cc
@@ -43,7 +43,7 @@ Square Computer::miniscore () {
                     cout << "(" << x_try << ", " << y_try << "): " << current_scores.front() << endl;
                 }
                 
-                int current_scores_max = std::max_element(current_scores.front(), current_scores.back());
+                int current_scores_max = *std::max_element(current_scores.begin(), current_scores.end());
                 if (current_scores_max > best_score) {   // If the algorithm finds a move that is better than the previous best, it updates its "recommended move".
                     best_score = current_scores_max;
                     x = x_try; y = y_try;
@@ -118,7 +118,7 @@ std::deque<int> Computer::miniscore_score (int x, int y, Player* player, int cur
                 }
                 
                 // Chooses best opponent score.
-                int opponent_scores_max = std::max_element(opponent_scores.begin(), opponent_scores.end());
+                int opponent_scores_max = *std::max_element(opponent_scores.begin(), opponent_scores.end());
                 if (best_opponent_scores_max < opponent_scores_max) {
                     best_opponent_scores_max = opponent_scores_max;
                     best_opponent_scores     = opponent_scores;

--- a/structures/algorithms/miniscore.cc
+++ b/structures/algorithms/miniscore.cc
@@ -58,13 +58,13 @@ Square Computer::miniscore () {
 
 /* miniscore score evaluator. 
 Moves recursively down the whole game tree in order to calculate the score of the optimal move. */
-int Computer::miniscore_score (int x, int y, Player* player, int current_depth, bool dev_details) {
+std::deque<int> Computer::miniscore_score (int x, int y, Player* player, int current_depth, bool dev_details) {
     int new_depth = current_depth + 1;
     
     // Makes test move to evaluate opponent's optimal score in that scenario.
     this->board->place(x, y, player->stone());   // Make temporary test move. Has to be undone before returning a score.
     Square test_move = Square(this->board, x, y);
-    int score;
+    std::deque<int> player_scores;
 
     // Header in Developer Mode offering an input.
     if (dev_details) {
@@ -89,11 +89,11 @@ int Computer::miniscore_score (int x, int y, Player* player, int current_depth, 
         this->is_winner(test_move) or 
         this->board->is_full()) 
     {   // Checks wether the `test_move` is a winning one for `player`.
-        score = score_win(test_move, minimax_winning_score);
+        player_scores.push_front(score_win(test_move, minimax_winning_score));
     } 
     else {   // If it hasn't won with this move, the algorithm evaluates the best score the opponent can achieve.
-        int best_opponent_score = -miniscore_winning_score;   // Again, starting with the lowest assumption.
-        bool board_is_full = true;   // If below, now square is found to be empty, this value will remain true.
+        std::deque<int> best_opponent_scores = {-miniscore_winning_score};   // Again, starting with the lowest assumption.
+        int best_opponent_score = -miniscore_winning_score;
         int x_try; int y_try;
 
         // Evaluates every opponent move and selects the first best one.
@@ -103,7 +103,7 @@ int Computer::miniscore_score (int x, int y, Player* player, int current_depth, 
 
             if (this->board->at(x_try, y_try) == empty) {
                 // Recursively evaluates opponent's score.
-                int opponent_score = this->miniscore_score(x_try, y_try, player->next(), new_depth);
+                std::deque<int> opponent_scores = this->miniscore_score(x_try, y_try, player->next(), new_depth);
                 
                 // Prints opponent's score when asked for in Developer Mode.
                 if (dev_details) {
@@ -111,13 +111,17 @@ int Computer::miniscore_score (int x, int y, Player* player, int current_depth, 
                 }
                 
                 // Chooses best opponent score.
-                best_opponent_score = std::max(best_opponent_score, opponent_score);
-                board_is_full = false;
+                int opponent_scores_max = std::max_element(opponent_scores.front(), opponent_scores.back());
+                if (best_opponent_score < opponent_scores_max) {
+                    best_opponent_score = opponent_scores_max;
+                    best_opponent_scores = opponent_scores;
+                }
             }
         }
 
         // The score of the test move is negative that of the optimal countermove.
-        score = -best_opponent_score;
+        player_scores = best_opponent_scores;
+        player_scores.push_front(-best_opponent_score);
     }
 
     // Offers a second input prompt in Developer Mode.
@@ -128,5 +132,8 @@ int Computer::miniscore_score (int x, int y, Player* player, int current_depth, 
 
     // Undoes the temporary move and returns its score.
     this->board->place(x, y, empty); 
-    return score;
+    if (player_scores.size() >= this->group->length()) {
+        player_scores.pop_back();
+    }
+    return player_scores;
 }

--- a/structures/class_headers/player.hh
+++ b/structures/class_headers/player.hh
@@ -86,7 +86,7 @@ class Computer : public Player {
 
         // Algorithm support methods. Found insde the respective algorithm files.
             int minimax_score (int x, int y, Player* player, bool dev_details = false);
-            int miniscore_score (int x, int y, Player* player, int depth, bool dev_details = false);
+            std::deque<int> miniscore_score (int x, int y, Player* player, int depth, bool dev_details = false);
 
 
         // Algorithm scoring methods. Implementation in 'algorithms/scoring/' folder.

--- a/structures/class_headers/player.hh
+++ b/structures/class_headers/player.hh
@@ -3,6 +3,9 @@
 
 
 
+class Group;
+
+
 // Player is the base class that acts on the board.
 class Player {
     protected:
@@ -12,7 +15,8 @@ class Player {
 
         // Set by public methods.
             Square latest_move;   // Changed by place_stone().
-            Player* next_player;   // Changed by Group::append() and Group::pop().
+            Group* group;              // Changed by Group::append() and Group::pop().
+            Player* next_player;       // Changed by Group::append() and Group::pop().
             Player* previous_player;   // Changed by Group::append() and Group::pop().
 
 

--- a/structures/class_members/computer.cc
+++ b/structures/class_members/computer.cc
@@ -38,7 +38,7 @@ void Computer::dev_choice (Player* player, int depth) {
                 if (this->algorithm_used == &Computer::placeholder)   score = 0;
                 if (this->algorithm_used == &Computer::minimax)       score = this->minimax_score(x, y, player, true);
                 if (this->algorithm_used == &Computer::miniscore) {
-                    score = this->miniscore_score(x, y, player, depth, true);
+                    score = this->miniscore_score(x, y, player, depth, true).front();
                 }
 
                 cout << "depth " << depth << ": "

--- a/structures/class_members/group.cc
+++ b/structures/class_members/group.cc
@@ -51,21 +51,24 @@ void Group::append (Player* new_player) {
     }
 
 
-    // If there's more than one player left in the group
+    // If there's more than one player in the group
     else {
         // The old last player becomes the second-to-last.
         Player* old_last_player      = this->first()->prev();
         old_last_player->next_player = new_player;
         
         // The new player becomes the new last player.
-        new_player->previous_player     = old_last_player;
-        new_player->next_player         = this->first();
+        new_player->previous_player    = old_last_player;
+        new_player->next_player        = this->first();
         this->first()->previous_player = new_player;
     }
 
 
     // The groups player count is incremented.
     this->number_of_players++;
+
+    // The group is pointed to in the new player.
+    new_player->group = this;
 }
 
 
@@ -88,6 +91,7 @@ Player* Group::pop () {
 
         // Then this player is deleted from the group and returned by the function.
         Player* leaving_player  = this->first();
+        leaving_player->group   = nullptr;
         this->first_player      = nullptr;
         this->number_of_players = 0;
         return leaving_player;
@@ -108,6 +112,7 @@ Player* Group::pop () {
         // The leaving player is stripped of its links and returned by the function.
         leaving_player->previous_player = nullptr;
         leaving_player->next_player     = nullptr;
+        leaving_player->group           = nullptr;
         return leaving_player;
     }
 }

--- a/structures/include.hh
+++ b/structures/include.hh
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <vector>
+#include <deque>
 
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
# Overview
* Implemented last feature of objective 1, project 03. Tests not yet done.
* Tweaked `miniscore()` and related structures to properly handle a multi-player game.

# Algorithms
* Rewrote `miniscore_score()` to return a deque of opponent scores instead of a single opponent score.
  + The method now calculates the score of the currently tested move as the negative maximum score from all subsequent moves and all players (as opposed to just the negative max of one player).
  + That way, any gain of any other player is treated as equally bad when calculating the score of the tested move.
* A deque was chosen as data structure as this allows the algorithm to push the currently considered player's score to the front while popping the upcoming player's score from the back. 
  + That way, `miniscore_score()` always receives a deque of only the other player's scores from the `miniscore_score()` instances it calls.
* `miniscore()` was adjusted analogously to calculate the best move out of a deque of opponent scores for every possible move.
* Developer Mode code inside the two methods got basic compatibility tweaks but will need to be rewritten for the upcoming tests.

# Structures
* `include.hh` now also includes `<deques>`.
* The Player class now also contains a pointer `group` to a Player's group.
  + That pointer is changed by the Group methods `append()` and `pop`.
  + It is needed by `miniscore_score()` when deciding whether to pop a score from the deque before returning it.
* `Computer::dev_choice()` got a compatibility tweak.

# Project
* `to_do.md` got some more detailed instructions for how to finish objective 1.
